### PR TITLE
Fix generation errors in non-English locales

### DIFF
--- a/Weiche/Program.cs
+++ b/Weiche/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
+using System.Threading;
+using System.Globalization;
 
 namespace Weiche
 {
@@ -11,6 +13,7 @@ namespace Weiche
         [STAThread]
         static void Main()
         {
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Weichengenerator());

--- a/Weiche/Program.cs
+++ b/Weiche/Program.cs
@@ -13,7 +13,7 @@ namespace Weiche
         [STAThread]
         static void Main()
         {
-			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(CultureInfo.InvariantCulture.Name);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Weichengenerator());


### PR DESCRIPTION
TrackGen currently does not have a standard locale when handling double to string conversion. This causes generation errors when running the program under locales which do not use a dot (.) as the decimal separator. Example:

Vertex generated in TrackGen: -1.6, 0, 23.5
CSV output with English locale (expected): -1.6, 0, 23.5
CSV output with other locales (causes errors): -1,6, 0, 23,5

This commit fixes the error by applying the English locale to number conversions.